### PR TITLE
Fix build issues on modern Linux systems (eg. Arch Linux)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 
 project(RISCV-Simulator)
 

--- a/src/ToDirenoTrace.cpp
+++ b/src/ToDirenoTrace.cpp
@@ -6,6 +6,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <cstdint>
 
 bool parseParameters(int argc, char **argv);
 void printUsage();


### PR DESCRIPTION
The PR fix two very little issues when building the Simulator on Arch Linux using last cmake and gcc versions. 
- Updates CMakeLists.txt minimum_required(<version>). From 3.2 to 3.5 needed for building (at least in my system).
- Add an include directive of #include <cstdint> in src/ToDirenoTrace.cpp for int32_t. I choose adding the directive only in the cpp instead of the .h in order to minimize the change of the final binary. 